### PR TITLE
footnote fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ LaTeX document class for writing theses
 
 TODO:
  - Fix frontpage dependencies (ask Magnus)
- - Fix footnote marker in actual footnote
  - Fix math font
  - Fix kerning and protrusion
    - Add microtype

--- a/examples/basic/thesis.tex
+++ b/examples/basic/thesis.tex
@@ -46,11 +46,15 @@
 
 We can use the \ac{api} to do stuff!
 
-It is fun to use modern \upsc{OpenMP} technology!
+It is fun to use modern \upsc{OpenMP} technology!\footnote{This is a snarky
+footnote. Words and etc. Semantic web technologies are technologies that enable
+semantification of the Web as we know it today. Hopefully this spans some lines
+now.}
 
 It is fun to use \emph{modern \upsc{OpenMP}} technology!
 
-Referencing figure \ref{fig:ex} to test link.
+Referencing figure \ref{fig:ex} to test link.\footnote{This is another
+footnote.}
 
 \begin{figure}\label{fig:ex}
 \centering

--- a/uit-thesis.cls
+++ b/uit-thesis.cls
@@ -277,6 +277,12 @@
 % Fix head height
 \setlength{\headheight}{15pt}
 
+%:-------------------------- Footnote fix ----------------------------
+\usepackage{scrextend}
+
+% sorry, I don't remember what these numbers mean
+\deffootnote[2.5em]{2.5em}{2.5em}{\thefootnotemark\space}
+
 %:-------------------------- Black magic hacks -----------------------
 
 % Used together with small caps to achieve fake emphasized (actually slanted) small caps


### PR DESCRIPTION
Footnote markers should be superscripted in main text, but it makes NO SENSE to have them as superscript in the footer. Plus also footnotes should not be indented all weird like as they are by default.
