### PR TITLE
Make sure ToC-commands do not have side-effects if called multiple times

### DIFF
--- a/examples/basic/thesis.tex
+++ b/examples/basic/thesis.tex
@@ -44,6 +44,8 @@
 %:-------------------------- Frontmatter -----------------------
 \frontmatter
 
+\tableofcontents
+
 %:-------------------------- Mainmatter -----------------------
 \mainmatter
 

--- a/uit-thesis.cls
+++ b/uit-thesis.cls
@@ -122,7 +122,7 @@
       % Re-define macro
       \expandafter\renewcommand\csname\expandafter\@gobble\string#1\endcsname{%
         % Error on third usage
-        \@latex@error{Duplicate call to \@backslashchar\expandafter\@gobble\string#1}
+        \@latex@error{Duplicate call to \@backslashchar\expandafter\@gobble\string#1}\@ehd
       }%
     }%
   }%
@@ -1028,9 +1028,16 @@
 
   % Make sure that abbreviations are not expanded
   \glsunsetall
+}
 
-  % Add TOC
-  \tableofcontents
+% Table of Contents
+\let\ult@savetableofcontents\tableofcontents
+\renewcommand\tableofcontents{%
+  \ult@savetableofcontents
+
+  \renewcommand\tableofcontents{%
+    \@latex@error{Duplicate \@backslashchar tableofcontents}\@ehd
+  }
 
   % LISTS
   % 1: Figures/illustrations
@@ -1056,7 +1063,6 @@
   \fi
 
   % Abstract
-
 }
 
 \let\ult@savemainmatter\mainmatter


### PR DESCRIPTION
Currently used on the \tableofcontents, \listoffigures, \listoftables, and
\lstlistoflistings macros.

The listings package caused me lots of headache, becuase the implementation uses
a filthy hack where \tableofcontents is called to output the List of Listings
when calling \lstlistoflistings.

I have overridden the \lstlistoflistings command to use the styling from the
tocloft package (since this had to be done anyways), and that also solves this
problem :)
