### PR TITLE
a man who would letterspace lowercase would steal sheep

### DIFF
--- a/texmf-tds/tex/latex/uit-thesis/uit-thesis.cls
+++ b/texmf-tds/tex/latex/uit-thesis/uit-thesis.cls
@@ -438,11 +438,11 @@
 \usepackage[activate={true,nocompatibility},final,kerning=true,spacing=true,factor=1100,stretch=10,shrink=10]{microtype}
 
 % this is necessary so that smallcapped italics & bolds also get spaced
-\DeclareMicrotypeSet{mysmallcaps}
+\DeclareMicrotypeSet{ultsmallcaps}
    { encoding = {OT1,T1,T2A,LY1,OT4,QX,T5,TS1,EU1,EU2},
      shape    = {sc,si,scit}
    }
-\microtypesetup{tracking=mysmallcaps}
+\microtypesetup{tracking=ultsmallcaps}
 
 % the default tracking is kind of huge, this sets tracking to 5.5% of an em
 \SetTracking{encoding = *, shape = {sc,si,scit}}{55}
@@ -846,6 +846,7 @@
 \DeclareRobustCommand{\scaledsc}[1]{%
   \begingroup%
   \scalefont{1.12}%
+  \microtypesetup{tracking=false}% Disable tracking to reduce letterspacing for acronyms and similar
   \textsc{#1}%
   \endgroup%
 }


### PR DESCRIPTION
Small caps should be letterspaces 5-10% of the font size so as not to appear so bunched up; ideally full caps should be spaced similarly, but it's proving too big a pain in the arse for now.

Please compare:
![screen shot 2014-03-19 at 19 13 54](https://f.cloud.github.com/assets/1435920/2464068/a6427c5a-af92-11e3-9f82-b23d544f564f.png)
![screen shot 2014-03-19 at 19 12 24](https://f.cloud.github.com/assets/1435920/2464070/a88e7c20-af92-11e3-88ba-b6237ac2ee60.png)
![screen shot 2014-03-19 at 19 14 14](https://f.cloud.github.com/assets/1435920/2464091/d590a018-af92-11e3-917e-8fd017cecc80.png)
![screen shot 2014-03-19 at 19 14 36](https://f.cloud.github.com/assets/1435920/2464092/d7984a3c-af92-11e3-86a7-a5a430630b41.png)
