### PR TITLE
Add support for nynorsk language

### DIFF
--- a/texmf-tds/tex/latex/uit-thesis/uit-thesis.cls
+++ b/texmf-tds/tex/latex/uit-thesis/uit-thesis.cls
@@ -625,6 +625,23 @@
 \renameautorefname[norsk]{part}{del}
 \renameautorefname[norsk]{appendix}{tillegg}
 
+% Set autoref definitions for nynorsk language - none of these are set.
+\renameautorefname[nynorsk]{section}{seksjon}
+\renameautorefname[nynorsk]{footnote}{fotnote}
+\renameautorefname[nynorsk]{item}{element}
+\renameautorefname[nynorsk]{chapter}{kapittel}
+\renameautorefname[nynorsk]{subsection}{underseksjon}
+\renameautorefname[nynorsk]{paragraph}{avsnitt}
+\renameautorefname[nynorsk]{subparagraph}{underavsnitt}
+\renameautorefname[nynorsk]{FancyVerbLine}{Line}
+\renameautorefname[nynorsk]{page}{side}
+\renameautorefname[nynorsk]{equation}{formel}
+\renameautorefname[nynorsk]{table}{tabell}
+\renameautorefname[nynorsk]{figure}{figur}
+\renameautorefname[nynorsk]{lstlisting}{listing}
+\renameautorefname[nynorsk]{part}{del}
+\renameautorefname[nynorsk]{appendix}{tillegg}
+
 
 %:-------------------------- Title and subtitle  -----------------------
 
@@ -1570,6 +1587,8 @@
 \renamedefname[USenglish]{ack}{Acknowledgements}
 \renamedefname[norsk]{abstract}{Sammendrag}
 \renamedefname[norsk]{ack}{Takksigelser}
+\renamedefname[nynorsk]{abstract}{Samendrag}
+\renamedefname[nynorsk]{ack}{Forord}
 
 % Missing from samin babel package
 \renamedefname[samin]{ack}{Giitosat}
@@ -1577,6 +1596,7 @@
 
 % Defined incorrectly with capital first letter in babel's 'norsk'
 \renamedefname[norsk]{see}{se}
+\renamedefname[nynorsk]{see}{sjå}
 
 % Control-ifs
 \newif\ifult@hasacknowledgement\ult@hasacknowledgementfalse
@@ -1901,6 +1921,7 @@
 % List of Listings
 \renamedefname[USenglish]{lstlistlisting}{List of Listings}
 \renamedefname[norsk]{lstlistlisting}{Listinger}
+\renamedefname[norsk]{lstlistlisting}{Listingar}
 \renewcommand\lstlistoflistings{%
   \iftotallstlistings% Only output list if count > 0
     \cleardoublepage
@@ -1914,6 +1935,7 @@
 % List of Abbreviations
 \renamedefname[USenglish]{acronym}{List of Abbreviations}
 \renamedefname[norsk]{acronym}{Forkortelser}
+\renamedefname[nynorsk]{acronym}{Forkortingar}
 
 \usepackage{ult-printglossary}
 
@@ -2472,6 +2494,10 @@
 \iflanguage{norsk}{%
   % Set the topleft frontpage logo to Norwegian
   \gdef\ult@frontpage@logo{ult_logo_norsk.pdf}
+}{}
+\iflanguage{nynorsk}{%
+  % Set the topleft frontpage logo to Norwegian
+  \gdef\ult@frontpage@logo{ult_logo_nynorsk.pdf}
 }{}
 
 % samin language - changes the frontpage logos and profile to the Sami language


### PR DESCRIPTION
`nynorsk` is supported by babel, but I guess it still needs the same hand-holding as bokmål in this thesis template.

I would love to update the documentation as well to reflect the fact that nynorsk is supported after this PR but I couldn't find the documentation as part of this repository.